### PR TITLE
Updated Secret Question Authenticator example

### DIFF
--- a/examples/providers/authenticator/README.md
+++ b/examples/providers/authenticator/README.md
@@ -17,7 +17,7 @@ Example Custom Authenticator
 
 6. In your copy, click the "Actions" menu item and "Add Execution".  Pick Secret Question
 
-7. Next you have to register the required action that you created. Click on the Required Actions tab in the Authenticaiton menu.
+7. Next you have to register the required action that you created. Click on the Required Actions tab in the Authentication menu.
    Click on the Register button and choose your new Required Action.
    Your new required action should now be displayed and enabled in the required actions list.
 

--- a/examples/providers/authenticator/secret-question.ftl
+++ b/examples/providers/authenticator/secret-question.ftl
@@ -1,4 +1,4 @@
-<#import "template.ftl" as layout>
+<#import "select.ftl" as layout>
 <@layout.registrationLayout; section>
     <#if section = "title">
         ${msg("loginTitle",realm.name)}
@@ -24,8 +24,9 @@
 
                 <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
                     <div class="${properties.kcFormButtonsWrapperClass!}">
-                        <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
-                        <input class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" name="cancel" id="kc-cancel" type="submit" value="${msg("doCancel")}"/>
+                        <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
+                        <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
+                               name="login" id="kc-login" type="submit" value="${msg("doLogIn")}"/>
                     </div>
                 </div>
             </div>

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
@@ -43,8 +43,6 @@ import java.net.URI;
  */
 public class SecretQuestionAuthenticator implements Authenticator, CredentialValidator<SecretQuestionCredentialProvider> {
 
-    public static final String CREDENTIAL_TYPE = "secret_question";
-
     protected boolean hasCookie(AuthenticationFlowContext context) {
         Cookie cookie = context.getHttpRequest().getHttpHeaders().getCookies().get("SECRET_QUESTION_ANSWERED");
         boolean result = cookie != null;
@@ -67,8 +65,6 @@ public class SecretQuestionAuthenticator implements Authenticator, CredentialVal
 
     @Override
     public void action(AuthenticationFlowContext context) {
-        MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
-
         boolean validated = validateAnswer(context);
         if (!validated) {
             Response challenge =  context.form()
@@ -141,6 +137,6 @@ public class SecretQuestionAuthenticator implements Authenticator, CredentialVal
 
     @Override
     public SecretQuestionCredentialProvider getCredentialProvider(KeycloakSession session) {
-        return (SecretQuestionCredentialProvider)session.getProvider(CredentialProvider.class, "secret-question");
+        return (SecretQuestionCredentialProvider)session.getProvider(CredentialProvider.class, SecretQuestionCredentialProviderFactory.PROVIDER_ID);
     }
 }

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
@@ -21,7 +21,10 @@ import org.jboss.resteasy.spi.HttpResponse;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.CredentialValidator;
 import org.keycloak.common.util.ServerCookie;
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.forms.login.freemarker.model.AuthenticationContextBean;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -38,7 +41,7 @@ import java.net.URI;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class SecretQuestionAuthenticator implements Authenticator {
+public class SecretQuestionAuthenticator implements Authenticator, CredentialValidator<SecretQuestionCredentialProvider> {
 
     public static final String CREDENTIAL_TYPE = "secret_question";
 
@@ -57,17 +60,15 @@ public class SecretQuestionAuthenticator implements Authenticator {
             context.success();
             return;
         }
-        Response challenge = context.form().createForm("secret-question.ftl");
+        Response challenge = context.form()
+                .createForm("secret-question.ftl");
         context.challenge(challenge);
     }
 
     @Override
     public void action(AuthenticationFlowContext context) {
         MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
-        if (formData.containsKey("cancel")) {
-            context.cancelLogin();
-            return;
-        }
+
         boolean validated = validateAnswer(context);
         if (!validated) {
             Response challenge =  context.form()
@@ -107,10 +108,15 @@ public class SecretQuestionAuthenticator implements Authenticator {
     protected boolean validateAnswer(AuthenticationFlowContext context) {
         MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
         String secret = formData.getFirst("secret_answer");
-        UserCredentialModel input = new UserCredentialModel();
-        input.setType(SecretQuestionCredentialProvider.SECRET_QUESTION);
-        input.setValue(secret);
-        return context.getSession().userCredentialManager().isValid(context.getRealm(), context.getUser(), input);
+        String credentialId = context.getSelectedCredentialId();
+        if (credentialId == null || credentialId.isEmpty()) {
+            credentialId = getCredentialProvider(context.getSession())
+                    .getDefaultCredential(context.getSession(), context.getRealm(), context.getUser()).getId();
+            context.setSelectedCredentialId(credentialId);
+        }
+
+        UserCredentialModel input = new UserCredentialModel(credentialId, getType(context.getSession()), secret);
+        return getCredentialProvider(context.getSession()).isValid(context.getRealm(), context.getUser(), input);
     }
 
     @Override
@@ -120,7 +126,7 @@ public class SecretQuestionAuthenticator implements Authenticator {
 
     @Override
     public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
-        return session.userCredentialManager().isConfiguredFor(realm, user, SecretQuestionCredentialProvider.SECRET_QUESTION);
+        return getCredentialProvider(session).isConfiguredFor(realm, user, getType(session));
     }
 
     @Override
@@ -131,5 +137,10 @@ public class SecretQuestionAuthenticator implements Authenticator {
     @Override
     public void close() {
 
+    }
+
+    @Override
+    public SecretQuestionCredentialProvider getCredentialProvider(KeycloakSession session) {
+        return (SecretQuestionCredentialProvider)session.getProvider(CredentialProvider.class, "secret-question");
     }
 }

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticator.java
@@ -24,7 +24,6 @@ import org.keycloak.authentication.Authenticator;
 import org.keycloak.authentication.CredentialValidator;
 import org.keycloak.common.util.ServerCookie;
 import org.keycloak.credential.CredentialProvider;
-import org.keycloak.forms.login.freemarker.model.AuthenticationContextBean;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticatorFactory.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionAuthenticatorFactory.java
@@ -50,6 +50,7 @@ public class SecretQuestionAuthenticatorFactory implements AuthenticatorFactory,
 
     private static AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
             AuthenticationExecutionModel.Requirement.REQUIRED,
+            AuthenticationExecutionModel.Requirement.ALTERNATIVE,
             AuthenticationExecutionModel.Requirement.DISABLED
     };
     @Override

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionCredentialProvider.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionCredentialProvider.java
@@ -19,7 +19,6 @@ package org.keycloak.examples.authenticator;
 import org.jboss.logging.Logger;
 import org.keycloak.common.util.Time;
 import org.keycloak.credential.CredentialInput;
-import org.keycloak.credential.CredentialInputUpdater;
 import org.keycloak.credential.CredentialInputValidator;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.credential.CredentialProvider;
@@ -29,13 +28,6 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
-import org.keycloak.models.cache.CachedUserModel;
-import org.keycloak.models.cache.OnUserCache;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionCredentialProvider.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionCredentialProvider.java
@@ -16,12 +16,15 @@
  */
 package org.keycloak.examples.authenticator;
 
+import org.jboss.logging.Logger;
 import org.keycloak.common.util.Time;
 import org.keycloak.credential.CredentialInput;
 import org.keycloak.credential.CredentialInputUpdater;
 import org.keycloak.credential.CredentialInputValidator;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.credential.CredentialProvider;
+import org.keycloak.credential.UserCredentialStore;
+import org.keycloak.examples.authenticator.credential.SecretQuestionCredentialModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserCredentialModel;
@@ -38,9 +41,8 @@ import java.util.Set;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class SecretQuestionCredentialProvider implements CredentialProvider, CredentialInputValidator, CredentialInputUpdater, OnUserCache {
-    public static final String SECRET_QUESTION = "SECRET_QUESTION";
-    public static final String CACHE_KEY = SecretQuestionCredentialProvider.class.getName() + "." + SECRET_QUESTION;
+public class SecretQuestionCredentialProvider implements CredentialProvider<SecretQuestionCredentialModel>, CredentialInputValidator {
+    private static final Logger logger = Logger.getLogger(SecretQuestionCredentialProvider.class);
 
     protected KeycloakSession session;
 
@@ -48,87 +50,60 @@ public class SecretQuestionCredentialProvider implements CredentialProvider, Cre
         this.session = session;
     }
 
-    public CredentialModel getSecret(RealmModel realm, UserModel user) {
-        CredentialModel secret = null;
-        if (user instanceof CachedUserModel) {
-            CachedUserModel cached = (CachedUserModel)user;
-            secret = (CredentialModel)cached.getCachedWith().get(CACHE_KEY);
-
-        } else {
-            List<CredentialModel> creds = session.userCredentialManager().getStoredCredentialsByType(realm, user, SECRET_QUESTION);
-            if (!creds.isEmpty()) secret = creds.get(0);
-        }
-        return secret;
+    private UserCredentialStore getCredentialStore() {
+        return session.userCredentialManager();
     }
 
 
     @Override
-    public boolean updateCredential(RealmModel realm, UserModel user, CredentialInput input) {
-        if (!SECRET_QUESTION.equals(input.getType())) return false;
-        if (!(input instanceof UserCredentialModel)) return false;
-        UserCredentialModel credInput = (UserCredentialModel) input;
-        List<CredentialModel> creds = session.userCredentialManager().getStoredCredentialsByType(realm, user, SECRET_QUESTION);
-        if (creds.isEmpty()) {
-            CredentialModel secret = new CredentialModel();
-            secret.setType(SECRET_QUESTION);
-            secret.setValue(credInput.getValue());
-            secret.setCreatedDate(Time.currentTimeMillis());
-            session.userCredentialManager().createCredential(realm ,user, secret);
-        } else {
-            creds.get(0).setValue(credInput.getValue());
-            session.userCredentialManager().updateCredential(realm, user, creds.get(0));
+    public boolean isValid(RealmModel realm, UserModel user, CredentialInput input) {
+        if (!(input instanceof UserCredentialModel)) {
+            logger.debug("Expected instance of UserCredentialModel for CredentialInput");
+            return false;
         }
-        session.userCache().evict(realm, user);
-        return true;
-    }
-
-    @Override
-    public void disableCredentialType(RealmModel realm, UserModel user, String credentialType) {
-        if (!SECRET_QUESTION.equals(credentialType)) return;
-
-        List<CredentialModel> credentials = session.userCredentialManager().getStoredCredentialsByType(realm, user, SECRET_QUESTION);
-        for (CredentialModel cred : credentials) {
-            session.userCredentialManager().removeStoredCredential(realm, user, cred.getId());
+        if (!input.getType().equals(getType())) {
+            return false;
         }
-        session.userCache().evict(realm, user);
-    }
-
-    @Override
-    public Set<String> getDisableableCredentialTypes(RealmModel realm, UserModel user) {
-        if (!session.userCredentialManager().getStoredCredentialsByType(realm, user, SECRET_QUESTION).isEmpty()) {
-            Set<String> set = new HashSet<>();
-            set.add(SECRET_QUESTION);
-            return set;
-        } else {
-            return Collections.EMPTY_SET;
+        String challengeResponse = input.getChallengeResponse();
+        if (challengeResponse == null) {
+            return false;
         }
-
+        CredentialModel credentialModel = getCredentialStore().getStoredCredentialById(realm, user, input.getCredentialId());
+        SecretQuestionCredentialModel sqcm = getCredentialFromModel(credentialModel);
+        return sqcm.getSecretQuestionSecretData().getAnswer().equals(challengeResponse);
     }
 
     @Override
     public boolean supportsCredentialType(String credentialType) {
-        return SECRET_QUESTION.equals(credentialType);
+        return getType().equals(credentialType);
     }
 
     @Override
     public boolean isConfiguredFor(RealmModel realm, UserModel user, String credentialType) {
-        if (!SECRET_QUESTION.equals(credentialType)) return false;
-        return getSecret(realm, user) != null;
+        if (!supportsCredentialType(credentialType)) return false;
+        return !getCredentialStore().getStoredCredentialsByType(realm, user, credentialType).isEmpty();
     }
 
     @Override
-    public boolean isValid(RealmModel realm, UserModel user, CredentialInput input) {
-        if (!SECRET_QUESTION.equals(input.getType())) return false;
-        if (!(input instanceof UserCredentialModel)) return false;
-
-        String secret = getSecret(realm, user).getValue();
-
-        return secret != null && ((UserCredentialModel)input).getValue().equals(secret);
+    public CredentialModel createCredential(RealmModel realm, UserModel user, SecretQuestionCredentialModel credentialModel) {
+        if (credentialModel.getCreatedDate() == null) {
+            credentialModel.setCreatedDate(Time.currentTimeMillis());
+        }
+        return getCredentialStore().createCredential(realm, user, credentialModel);
     }
 
     @Override
-    public void onCache(RealmModel realm, CachedUserModel user, UserModel delegate) {
-        List<CredentialModel> creds = session.userCredentialManager().getStoredCredentialsByType(realm, user, SECRET_QUESTION);
-        if (!creds.isEmpty()) user.getCachedWith().put(CACHE_KEY, creds.get(0));
+    public void deleteCredential(RealmModel realm, UserModel user, String credentialId) {
+        getCredentialStore().removeStoredCredential(realm, user, credentialId);
+    }
+
+    @Override
+    public SecretQuestionCredentialModel getCredentialFromModel(CredentialModel model) {
+        return SecretQuestionCredentialModel.createFromCredentialModel(model);
+    }
+
+    @Override
+    public String getType() {
+        return SecretQuestionCredentialModel.TYPE;
     }
 }

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionCredentialProviderFactory.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionCredentialProviderFactory.java
@@ -25,9 +25,12 @@ import org.keycloak.models.KeycloakSession;
  * @version $Revision: 1 $
  */
 public class SecretQuestionCredentialProviderFactory implements CredentialProviderFactory<SecretQuestionCredentialProvider> {
+
+    public static final String PROVIDER_ID =  "secret-question";
+
     @Override
     public String getId() {
-        return "secret-question";
+        return PROVIDER_ID;
     }
 
     @Override

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionRequiredAction.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionRequiredAction.java
@@ -22,7 +22,6 @@ import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.credential.CredentialProvider;
 import org.keycloak.examples.authenticator.credential.SecretQuestionCredentialModel;
-import org.keycloak.models.UserCredentialModel;
 
 import javax.ws.rs.core.Response;
 

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionRequiredAction.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/SecretQuestionRequiredAction.java
@@ -17,8 +17,11 @@
 
 package org.keycloak.examples.authenticator;
 
+import org.keycloak.authentication.CredentialRegistrator;
 import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.RequiredActionProvider;
+import org.keycloak.credential.CredentialProvider;
+import org.keycloak.examples.authenticator.credential.SecretQuestionCredentialModel;
 import org.keycloak.models.UserCredentialModel;
 
 import javax.ws.rs.core.Response;
@@ -27,7 +30,7 @@ import javax.ws.rs.core.Response;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class SecretQuestionRequiredAction implements RequiredActionProvider {
+public class SecretQuestionRequiredAction implements RequiredActionProvider, CredentialRegistrator {
     public static final String PROVIDER_ID = "secret_question_config";
 
     @Override
@@ -45,10 +48,8 @@ public class SecretQuestionRequiredAction implements RequiredActionProvider {
     @Override
     public void processAction(RequiredActionContext context) {
         String answer = (context.getHttpRequest().getDecodedFormParameters().getFirst("secret_answer"));
-        UserCredentialModel input = new UserCredentialModel();
-        input.setType(SecretQuestionCredentialProvider.SECRET_QUESTION);
-        input.setValue(answer);
-        context.getSession().userCredentialManager().updateCredential(context.getRealm(), context.getUser(), input);
+        SecretQuestionCredentialProvider sqcp = (SecretQuestionCredentialProvider) context.getSession().getProvider(CredentialProvider.class, "secret-question");
+        sqcp.createCredential(context.getRealm(), context.getUser(), SecretQuestionCredentialModel.createSecretQuestion("What is your mom's first name?", answer));
         context.success();
     }
 

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/credential/SecretQuestionCredentialModel.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/credential/SecretQuestionCredentialModel.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.examples.authenticator.credential;
+
+import org.keycloak.common.util.Time;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.examples.authenticator.credential.dto.SecretQuestionCredentialData;
+import org.keycloak.examples.authenticator.credential.dto.SecretQuestionSecretData;
+import org.keycloak.util.JsonSerialization;
+
+import java.io.IOException;
+
+/**
+ * @author <a href="mailto:alistair.doswald@elca.ch">Alistair Doswald</a>
+ * @version $Revision: 1 $
+ */
+public class SecretQuestionCredentialModel extends CredentialModel {
+    public static final String TYPE = "SECRET_QUESTION";
+
+    private final SecretQuestionCredentialData credentialData;
+    private final SecretQuestionSecretData secretData;
+
+    private SecretQuestionCredentialModel(SecretQuestionCredentialData credentialData, SecretQuestionSecretData secretData) {
+        this.credentialData = credentialData;
+        this.secretData = secretData;
+    }
+
+    private SecretQuestionCredentialModel(String question, String answer) {
+        credentialData = new SecretQuestionCredentialData(question);
+        secretData = new SecretQuestionSecretData(answer);
+    }
+
+    public static SecretQuestionCredentialModel createSecretQuestion(String question, String answer) {
+        SecretQuestionCredentialModel credentialModel = new SecretQuestionCredentialModel(question, answer);
+        credentialModel.fillCredentialModelFields();
+        return credentialModel;
+    }
+
+    public static SecretQuestionCredentialModel createFromCredentialModel(CredentialModel credentialModel){
+        try {
+            SecretQuestionCredentialData credentialData = JsonSerialization.readValue(credentialModel.getCredentialData(), SecretQuestionCredentialData.class);
+            SecretQuestionSecretData secretData = JsonSerialization.readValue(credentialModel.getSecretData(), SecretQuestionSecretData.class);
+
+            SecretQuestionCredentialModel secretQuestionCredentialModel = new SecretQuestionCredentialModel(credentialData, secretData);
+            secretQuestionCredentialModel.setUserLabel(credentialModel.getUserLabel());
+            secretQuestionCredentialModel.setCreatedDate(credentialModel.getCreatedDate());
+            secretQuestionCredentialModel.setType(TYPE);
+            secretQuestionCredentialModel.setId(credentialModel.getId());
+            secretQuestionCredentialModel.setSecretData(credentialModel.getSecretData());
+            secretQuestionCredentialModel.setCredentialData(credentialModel.getCredentialData());
+            return secretQuestionCredentialModel;
+        } catch (IOException e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    public SecretQuestionCredentialData getSecretQuestionCredentialData() {
+        return credentialData;
+    }
+
+    public SecretQuestionSecretData getSecretQuestionSecretData() {
+        return secretData;
+    }
+
+    private void fillCredentialModelFields(){
+        try {
+            setCredentialData(JsonSerialization.writeValueAsString(credentialData));
+            setSecretData(JsonSerialization.writeValueAsString(secretData));
+            setType(TYPE);
+            setCreatedDate(Time.currentTimeMillis());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/credential/dto/SecretQuestionCredentialData.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/credential/dto/SecretQuestionCredentialData.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.examples.authenticator.credential.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author <a href="mailto:alistair.doswald@elca.ch">Alistair Doswald</a>
+ * @version $Revision: 1 $
+ */
+public class SecretQuestionCredentialData {
+
+    private final String question;
+
+    @JsonCreator
+    public SecretQuestionCredentialData(@JsonProperty("question") String question) {
+        this.question = question;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+}

--- a/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/credential/dto/SecretQuestionSecretData.java
+++ b/examples/providers/authenticator/src/main/java/org/keycloak/examples/authenticator/credential/dto/SecretQuestionSecretData.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.examples.authenticator.credential.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author <a href="mailto:alistair.doswald@elca.ch">Alistair Doswald</a>
+ * @version $Revision: 1 $
+ */
+public class SecretQuestionSecretData {
+
+     private final String answer;
+
+    @JsonCreator
+     public SecretQuestionSecretData(@JsonProperty("answer") String answer) {
+         this.answer = answer;
+     }
+
+    public String getAnswer() {
+        return answer;
+    }
+}

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -198,9 +198,6 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
             attributes.put("isAppInitiatedAction", true);
         }
 
-        attributes.put("auth", new AuthenticationContextBean(context, actionUri));
-        attributes.put(Constants.EXECUTION, execution);
-
         switch (page) {
             case LOGIN_CONFIG_TOTP:
                 attributes.put("totp", new TotpBean(session, realm, user, uriInfo.getRequestUriBuilder()));
@@ -408,7 +405,8 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
 
             attributes.put("url", new UrlBean(realm, theme, baseUri, this.actionUri));
             attributes.put("requiredActionUrl", new RequiredActionUrlFormatterMethod(realm, baseUri));
-
+            attributes.put("auth", new AuthenticationContextBean(context, actionUri));
+            attributes.put(Constants.EXECUTION, execution);
 
             if (realm.isInternationalizationEnabled()) {
                 UriBuilder b;


### PR DESCRIPTION
The server developer's guide chapter on implementing an Authenticator SPI is based on an example in the keycloak repo. This had to be brought up to date with the changes for the multi-token prototype.
In addition to the changes to the authenticator example, the lines 
```
attributes.put("auth", new AuthenticationContextBean(context, actionUri));
attributes.put(Constants.EXECUTION, execution);
```
were moved from the `FreeMarkerLoginFormsProvider#createResponse(LoginFormsPages page)` method to the `FreeMarkerLoginFormsProvider#createCommonAttributes` page, to allow authenticator modules to easily create pages that use select.ftl as a template.