### PR TITLE
[KEYCLOAK-11753] Introduce the ability to add OTP label, when creating OTP credential via 'Configure-OTP' required action or via 'Reset-OTP' authenticator in 'Reset Credentials' flow

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/requiredactions/ConsoleUpdateTotp.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/ConsoleUpdateTotp.java
@@ -74,9 +74,10 @@ public class ConsoleUpdateTotp implements RequiredActionProvider {
         MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
         String challengeResponse = formData.getFirst("totp");
         String totpSecret = context.getAuthenticationSession().getAuthNote("totpSecret");
+        String userLabel = formData.getFirst("userLabel");
 
         OTPPolicy policy = context.getRealm().getOTPPolicy();
-        OTPCredentialModel credentialModel = OTPCredentialModel.createFromPolicy(context.getRealm(), totpSecret);
+        OTPCredentialModel credentialModel = OTPCredentialModel.createFromPolicy(context.getRealm(), totpSecret, userLabel);
         if (Validation.isBlank(challengeResponse)) {
             context.challenge(challenge(context).message(Messages.MISSING_TOTP));
             return;

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateTotp.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateTotp.java
@@ -69,9 +69,10 @@ public class UpdateTotp implements RequiredActionProvider, RequiredActionFactory
         String challengeResponse = formData.getFirst("totp");
         String totpSecret = formData.getFirst("totpSecret");
         String mode = formData.getFirst("mode");
+        String userLabel = formData.getFirst("userLabel");
 
         OTPPolicy policy = context.getRealm().getOTPPolicy();
-        OTPCredentialModel credentialModel = OTPCredentialModel.createFromPolicy(context.getRealm(), totpSecret);
+        OTPCredentialModel credentialModel = OTPCredentialModel.createFromPolicy(context.getRealm(), totpSecret, userLabel);
         if (Validation.isBlank(challengeResponse)) {
             Response challenge = context.form()
                     .setAttribute("mode", mode)

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/AccountTotpPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/AccountTotpPage.java
@@ -33,6 +33,9 @@ public class AccountTotpPage extends AbstractAccountPage {
     @FindBy(id = "totp")
     private WebElement totpInput;
 
+    @FindBy(id = "userLabel")
+    private WebElement totpLabelInput;
+
     @FindBy(css = "button[type=\"submit\"]")
     private WebElement submitButton;
 
@@ -52,6 +55,12 @@ public class AccountTotpPage extends AbstractAccountPage {
     public void configure(String totp) {
         totpInput.sendKeys(totp);
         submitButton.click();
+    }
+
+   public void configure(String totp, String userLabel) {
+       totpInput.sendKeys(totp);
+       totpLabelInput.sendKeys(userLabel);
+       submitButton.click();
     }
 
     public String getTotpSecret() {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginConfigTotpPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginConfigTotpPage.java
@@ -30,6 +30,9 @@ public class LoginConfigTotpPage extends AbstractPage {
     @FindBy(id = "totp")
     private WebElement totpInput;
 
+    @FindBy(id = "userLabel")
+    private WebElement totpLabelInput;
+
     @FindBy(css = "input[type=\"submit\"]")
     private WebElement submitButton;
     
@@ -47,6 +50,12 @@ public class LoginConfigTotpPage extends AbstractPage {
 
     public void configure(String totp) {
         totpInput.sendKeys(totp);
+        submitButton.click();
+    }
+
+    public void configure(String totp, String userLabel) {
+        totpInput.sendKeys(totp);
+        totpLabelInput.sendKeys(userLabel);
         submitButton.click();
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionTotpSetupTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionTotpSetupTest.java
@@ -135,6 +135,9 @@ public class RequiredActionTotpSetupTest extends AbstractTestRealmKeycloakTest {
 
         assertTrue(totpPage.isCurrent());
 
+        // KEYCLOAK-11753 - Verify OTP label element present on "Configure OTP" required action form
+        driver.findElement(By.id("userLabel"));
+
         totpPage.configure(totp.generateTOTP(totpPage.getTotpSecret()));
 
         String authSessionId = events.expectRequiredAction(EventType.UPDATE_TOTP).user(userId).detail(Details.USERNAME, "setuptotp").assertEvent()
@@ -197,6 +200,9 @@ public class RequiredActionTotpSetupTest extends AbstractTestRealmKeycloakTest {
 
         assertTrue(pageSource.contains("Unable to scan?"));
         assertFalse(pageSource.contains("Scan barcode?"));
+
+        // KEYCLOAK-11753 - Verify OTP label element present on "Configure OTP" required action form
+        driver.findElement(By.id("userLabel"));
     }
 
     // KEYCLOAK-7081
@@ -255,6 +261,32 @@ public class RequiredActionTotpSetupTest extends AbstractTestRealmKeycloakTest {
 
         assertFalse(pageSource.contains("Unable to scan?"));
         assertTrue(pageSource.contains("Scan barcode?"));
+    }
+
+    @Test
+    public void setupTotpRegisterVerifyCustomOtpLabelSetProperly() {
+        loginPage.open();
+        loginPage.clickRegister();
+        registerPage.register("firstName", "lastName", "email@mail.com", "setupTotp", "password", "password");
+
+        String userId = events.expectRegister("setupTotp", "email@mail.com").assertEvent().getUserId();
+
+        assertTrue(totpPage.isCurrent());
+
+        // KEYCLOAK-11753 - Verify OTP label element present on "Configure OTP" required action form
+        driver.findElement(By.id("userLabel"));
+
+        String customOtpLabel = "my-custom-otp-label";
+
+        // Set OTP label to a custom value
+        totpPage.configure(totp.generateTOTP(totpPage.getTotpSecret()), customOtpLabel);
+
+        // Open account page & verify OTP authenticator with requested label was created
+        accountTotpPage.open();
+        accountTotpPage.assertCurrent();
+
+        String pageSource = driver.getPageSource();
+        assertTrue(pageSource.contains(customOtpLabel));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
@@ -32,6 +32,7 @@ import org.keycloak.testsuite.pages.AppPage.RequestType;
 
 import org.keycloak.testsuite.util.*;
 import javax.mail.internet.MimeMessage;
+
 import static org.jgroups.util.Util.assertTrue;
 import static org.junit.Assert.assertEquals;
 
@@ -493,7 +494,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
 
     @Test
     public void registerExistingUser_emailAsUsername() {
-        configureRelamRegistrationEmailAsUsername(true);
+        configureRealmRegistrationEmailAsUsername(true);
 
         try {
             loginPage.open();
@@ -507,13 +508,13 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
 
             events.expectRegister("test-user@localhost", "test-user@localhost").user((String) null).error("email_in_use").assertEvent();
         } finally {
-            configureRelamRegistrationEmailAsUsername(false);
+            configureRealmRegistrationEmailAsUsername(false);
         }
     }
 
     @Test
     public void registerUserMissingOrInvalidEmail_emailAsUsername() {
-        configureRelamRegistrationEmailAsUsername(true);
+        configureRealmRegistrationEmailAsUsername(true);
 
         try {
             loginPage.open();
@@ -530,13 +531,13 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             assertEquals("Invalid email address.", registerPage.getError());
             events.expectRegister("registerUserInvalidEmailemail", "registerUserInvalidEmailemail").error("invalid_registration").assertEvent();
         } finally {
-            configureRelamRegistrationEmailAsUsername(false);
+            configureRealmRegistrationEmailAsUsername(false);
         }
     }
 
     @Test
     public void registerUserSuccess_emailAsUsername() {
-        configureRelamRegistrationEmailAsUsername(true);
+        configureRealmRegistrationEmailAsUsername(true);
 
         try {
             loginPage.open();
@@ -557,16 +558,16 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
             Assert.assertTrue((System.currentTimeMillis() - user.getCreatedTimestamp()) < 10000);
 
         } finally {
-            configureRelamRegistrationEmailAsUsername(false);
+            configureRealmRegistrationEmailAsUsername(false);
         }
     }
 
-    protected void configureRelamRegistrationEmailAsUsername(final boolean value) {
+    protected void configureRealmRegistrationEmailAsUsername(final boolean value) {
         RealmRepresentation realm = testRealm().toRepresentation();
         realm.setRegistrationEmailAsUsername(value);
         testRealm().update(realm);
     }
-    
+
     private void setDuplicateEmailsAllowed(boolean allowed) {
         RealmRepresentation testRealm = testRealm().toRepresentation();
         testRealm.setDuplicateEmailsAllowed(allowed);

--- a/themes/src/main/resources/theme/base/login/login-config-totp.ftl
+++ b/themes/src/main/resources/theme/base/login/login-config-totp.ftl
@@ -58,6 +58,16 @@
             <#if mode??><input type="hidden" id="mode" name="mode" value="${mode}"/></#if>
         </div>
 
+        <div class="${properties.kcFormGroupClass!}">
+            <div class="${properties.kcInputWrapperClass!}">
+                <label for="userLabel" class="control-label">Device Name</label>
+            </div>
+
+            <div class="${properties.kcInputWrapperClass!}">
+                <input type="text" class="form-control" id="userLabel" name="userLabel" autocomplete="off">
+            </div>
+        </div>
+
         <#if isAppInitiatedAction??>
         <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}" />
         <button class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!} ${properties.kcButtonLargeClass!}" type="submit" name="cancel-aia" value="true" />${msg("doCancel")}</button>


### PR DESCRIPTION

    [KEYCLOAK-11753] Introduce the possibility to add OTP label, when adding OTP code:
    * Through 'Configure-OTP' required action, or
    * Through 'Reset-OTP' authenticator in the 'Reset Credentials' flow

    Add testcases for both of the scenarios

    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
