### PR TITLE
KEYCLOAK-11874 User should be evicted from cache when their credential is deleted

### DIFF
--- a/services/src/main/java/org/keycloak/credential/UserCredentialStoreManager.java
+++ b/services/src/main/java/org/keycloak/credential/UserCredentialStoreManager.java
@@ -70,7 +70,9 @@ public class UserCredentialStoreManager implements UserCredentialManager, OnUser
 
     @Override
     public boolean removeStoredCredential(RealmModel realm, UserModel user, String id) {
-        return getStoreForUser(user).removeStoredCredential(realm, user, id);
+        boolean removalResult = getStoreForUser(user).removeStoredCredential(realm, user, id);
+        session.userCache().evict(realm, user);
+        return removalResult;
     }
 
     @Override


### PR DESCRIPTION
- added eviction of user after their credential was deleted
- added `UserTest.loginShouldFailAfterPasswordDeleted()`